### PR TITLE
Specify region for cloud function + formatting

### DIFF
--- a/cloudsql-export/README.md
+++ b/cloudsql-export/README.md
@@ -45,34 +45,40 @@ No modules.
 |------|------|
 | [google_cloud_scheduler_job.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_scheduler_job) | resource |
 | [google_cloudfunctions_function.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudfunctions_function) | resource |
-| [google_project_iam_binding.gcf_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_binding) | resource |
-| [google_project_iam_custom_role.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_member.gcf_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_pubsub_topic.cloudsql_export](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
 | [google_service_account.function_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_storage_bucket.function_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+| [google_storage_bucket_iam_member.backup_bucket_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_bucket_object.function_archive](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [archive_file.function_source](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
-| [google_project.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
+| [google_sql_database_instance.sql_database_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/sql_database_instance) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_backup_bucket"></a> [backup\_bucket](#input\_backup\_bucket) | Cloud Storage bucket name to store SQL export | `string` | n/a | yes |
-| <a name="input_cloud_scheduler_description"></a> [cloud\_scheduler\_description](#input\_cloud\_scheduler\_description) | Description of the cloud scheduler used to schedule Cloud SQL export. | `string` | n/a | yes |
+| <a name="input_cloud_scheduler_description"></a> [cloud\_scheduler\_description](#input\_cloud\_scheduler\_description) | Description of the cloud scheduler used to schedule Cloud SQL export. | `string` | `""` | no |
 | <a name="input_cloud_scheduler_name"></a> [cloud\_scheduler\_name](#input\_cloud\_scheduler\_name) | Name of the cloud scheduler used to Schdule Cloud SQL Export | `string` | n/a | yes |
-| <a name="input_cloud_scheduler_region"></a> [cloud\_scheduler\_region](#input\_cloud\_scheduler\_region) | Region to deploy Cloud Scheduler. This should be the same region with your app engine region | `string` | n/a | yes |
+| <a name="input_cloud_scheduler_region"></a> [cloud\_scheduler\_region](#input\_cloud\_scheduler\_region) | Region to deploy Cloud Scheduler. This defaults to `default_region` if not specified | `string` | `null` | no |
 | <a name="input_cloud_scheduler_schedule"></a> [cloud\_scheduler\_schedule](#input\_cloud\_scheduler\_schedule) | Schedule of the Cloud SQL export (in crontab format) | `string` | n/a | yes |
 | <a name="input_cloud_scheduler_time_zone"></a> [cloud\_scheduler\_time\_zone](#input\_cloud\_scheduler\_time\_zone) | Time zone of the cloud scheduler | `string` | n/a | yes |
-| <a name="input_cloudsql_database_names"></a> [cloudsql\_database\_names](#input\_cloudsql\_database\_names) | List of databases to be backup | `string` | n/a | yes |
+| <a name="input_cloudsql_database_names"></a> [cloudsql\_database\_names](#input\_cloudsql\_database\_names) | List of databases to be backup | `list(string)` | n/a | yes |
 | <a name="input_cloudsql_instance_name"></a> [cloudsql\_instance\_name](#input\_cloudsql\_instance\_name) | Cloud SQL instance name to be backup | `string` | n/a | yes |
+| <a name="input_cloudsql_project_id"></a> [cloudsql\_project\_id](#input\_cloudsql\_project\_id) | Cloud SQL instance project id to be backup | `string` | n/a | yes |
+| <a name="input_default_region"></a> [default\_region](#input\_default\_region) | Default region to use with regional resources. | `string` | n/a | yes |
+| <a name="input_export_object_suffix"></a> [export\_object\_suffix](#input\_export\_object\_suffix) | n/a | `string` | `""` | no |
 | <a name="input_function_archive_name"></a> [function\_archive\_name](#input\_function\_archive\_name) | Cloud function source code archive name. This file is the one that will be uploaded to Cloud Storage Bucket for Cloud Function Deployment | `string` | `"cloudsql_exporter.zip"` | no |
+| <a name="input_function_bucket_location"></a> [function\_bucket\_location](#input\_function\_bucket\_location) | Cloud Storage Bucket location to store Cloud Functions source code | `string` | n/a | yes |
 | <a name="input_function_bucket_name"></a> [function\_bucket\_name](#input\_function\_bucket\_name) | Cloud Storage Bucket Name to store Cloud Functions source code | `string` | n/a | yes |
 | <a name="input_function_description"></a> [function\_description](#input\_function\_description) | Cloud function description | `string` | `"Cloud SQL schduled export to Cloud Storage"` | no |
 | <a name="input_function_memory_mb"></a> [function\_memory\_mb](#input\_function\_memory\_mb) | Memory (in MB), available to the function. Default value is 128. | `string` | `"128"` | no |
 | <a name="input_function_name"></a> [function\_name](#input\_function\_name) | Cloud function name for Cloud SQL data export | `string` | `"cloudsql-data-export"` | no |
+| <a name="input_function_region"></a> [function\_region](#input\_function\_region) | The region to use with the Cloud Function. Defaults to `default_region` if not specified. | `string` | `null` | no |
 | <a name="input_function_runtime"></a> [function\_runtime](#input\_function\_runtime) | The runtime in which the function is going to run. | `string` | `"python38"` | no |
-| <a name="input_function_service_account_name"></a> [function\_service\_account\_name](#input\_function\_service\_account\_name) | Custom IAM service account name that will be used by Cloud Function. | `string` | n/a | yes |
+| <a name="input_function_service_account_id"></a> [function\_service\_account\_id](#input\_function\_service\_account\_id) | Service account id that will be used by Cloud Function. | `string` | n/a | yes |
+| <a name="input_function_service_account_name"></a> [function\_service\_account\_name](#input\_function\_service\_account\_name) | Custom IAM service account name that will be used by Cloud Function. | `string` | `""` | no |
 | <a name="input_label_environment"></a> [label\_environment](#input\_label\_environment) | label environment | `string` | `"production"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID where this stack should be deployed | `string` | n/a | yes |
 | <a name="input_topic_name"></a> [topic\_name](#input\_topic\_name) | PubSub Topic Name for Cloud Scheduler to post scheduler data which will trigger Cloud Function | `string` | n/a | yes |

--- a/cloudsql-export/cloud_function.tf
+++ b/cloudsql-export/cloud_function.tf
@@ -19,6 +19,7 @@ resource "google_storage_bucket_object" "function_archive" {
 
 resource "google_cloudfunctions_function" "main" {
   project     = var.project_id
+  region      = coalesce(var.function_region, var.default_region)
   name        = var.function_name
   description = var.function_description
   runtime     = var.function_runtime

--- a/cloudsql-export/cloud_scheduler.tf
+++ b/cloudsql-export/cloud_scheduler.tf
@@ -10,7 +10,7 @@ locals {
 
 resource "google_cloud_scheduler_job" "main" {
   project     = var.project_id
-  region      = var.cloud_scheduler_region
+  region      = coalesce(var.cloud_scheduler_region, var.default_region)
   name        = var.cloud_scheduler_name
   description = var.cloud_scheduler_description
   schedule    = var.cloud_scheduler_schedule

--- a/cloudsql-export/examples/test-stack/locals.tf
+++ b/cloudsql-export/examples/test-stack/locals.tf
@@ -1,12 +1,12 @@
 locals {
-  instance_prefix        = "hellomysql"
-  instance_name          = "${local.instance_prefix}-${random_id.suffix.hex}"
+  instance_prefix = "hellomysql"
+  instance_name   = "${local.instance_prefix}-${random_id.suffix.hex}"
 
-  project_id             = "aip-aliz-prod-mp-20210916"
-  region                 = "europe-west1"
-  
-  instance_tier          = "db-f1-micro"
-  instance_zone          = "europe-west1-b"
+  project_id = "aip-aliz-prod-mp-20210916"
+  region     = "europe-west1"
+
+  instance_tier = "db-f1-micro"
+  instance_zone = "europe-west1-b"
 
   export_bucket_name     = "${local.instance_name}-export"
   export_bucket_location = local.region

--- a/cloudsql-export/variables.tf
+++ b/cloudsql-export/variables.tf
@@ -4,9 +4,15 @@ variable "project_id" {
   description = "Project ID where this stack should be deployed"
 }
 
+variable "default_region" {
+  type        = string
+  description = "Default region to use with regional resources."
+}
+
 variable "cloud_scheduler_region" {
   type        = string
-  description = "Region to deploy Cloud Scheduler. This should be the same region with your app engine region"
+  description = "Region to deploy Cloud Scheduler. This defaults to `default_region` if not specified"
+  default     = null
 }
 
 # Label related variables
@@ -94,6 +100,12 @@ variable "function_runtime" {
   type        = string
   description = "The runtime in which the function is going to run. "
   default     = "python38"
+}
+
+variable "function_region" {
+  description = "The region to use with the Cloud Function. Defaults to `default_region` if not specified."
+  type        = string
+  default     = null
 }
 
 variable "function_name" {

--- a/monitoring/cloudsql/alert/main.tf
+++ b/monitoring/cloudsql/alert/main.tf
@@ -1,11 +1,11 @@
 locals {
-  user_labels_filter                          = join(" AND ", [for key, value in var.user_labels : "metadata.user_labels.${key} = \"${value}\""])
-  common_filter_parts                         = [
+  user_labels_filter = join(" AND ", [for key, value in var.user_labels : "metadata.user_labels.${key} = \"${value}\""])
+  common_filter_parts = [
     "resource.type = \"cloudsql_database\"",
     "resource.labels.project_id = \"${var.cloud_sql_project_id}\"",
     length(local.user_labels_filter) > 0 ? "(${local.user_labels_filter})" : ""
   ]
-  common_filter                               = join(" AND ", compact(local.common_filter_parts))
+  common_filter = join(" AND ", compact(local.common_filter_parts))
 }
 
 resource "google_monitoring_alert_policy" "cloud_sql_cpu_utilization" {
@@ -16,14 +16,14 @@ resource "google_monitoring_alert_policy" "cloud_sql_cpu_utilization" {
   conditions {
     display_name = "Cloud SQL Database - CPU utilization"
     condition_threshold {
-      filter          = "${local.common_filter} AND metric.type = \"cloudsql.googleapis.com/database/cpu/utilization\""
+      filter = "${local.common_filter} AND metric.type = \"cloudsql.googleapis.com/database/cpu/utilization\""
       aggregations {
         alignment_period     = "300s"
         cross_series_reducer = "REDUCE_NONE"
         per_series_aligner   = "ALIGN_MEAN"
       }
-      comparison      = "COMPARISON_GT"
-      duration        = "300s"
+      comparison = "COMPARISON_GT"
+      duration   = "300s"
       trigger {
         count = 1
       }
@@ -40,14 +40,14 @@ resource "google_monitoring_alert_policy" "cloud_sql_disk_utilization" {
   conditions {
     display_name = "Cloud SQL Database - Disk utilization"
     condition_threshold {
-      filter          = "${local.common_filter} metric.type = \"cloudsql.googleapis.com/database/disk/utilization\""
+      filter = "${local.common_filter} metric.type = \"cloudsql.googleapis.com/database/disk/utilization\""
       aggregations {
         alignment_period     = "300s"
         cross_series_reducer = "REDUCE_NONE"
         per_series_aligner   = "ALIGN_MEAN"
       }
-      comparison      = "COMPARISON_GT"
-      duration        = "60s"
+      comparison = "COMPARISON_GT"
+      duration   = "60s"
       trigger {
         count = 1
       }
@@ -64,14 +64,14 @@ resource "google_monitoring_alert_policy" "cloud_sql_memory_utilization" {
   conditions {
     display_name = "Cloud SQL Database - Memory utilization"
     condition_threshold {
-      filter          = "${local.common_filter} AND metric.type = \"cloudsql.googleapis.com/database/memory/utilization\""
+      filter = "${local.common_filter} AND metric.type = \"cloudsql.googleapis.com/database/memory/utilization\""
       aggregations {
         alignment_period     = "3600s"
         cross_series_reducer = "REDUCE_NONE"
         per_series_aligner   = "ALIGN_MEAN"
       }
-      comparison      = "COMPARISON_GT"
-      duration        = "60s"
+      comparison = "COMPARISON_GT"
+      duration   = "60s"
       trigger {
         count = 1
       }
@@ -89,7 +89,7 @@ resource "google_monitoring_alert_policy" "cloud_sql_instance_up" {
   conditions {
     display_name = "Cloud SQL Database - Instance up"
     condition_absent {
-      filter   = "${local.common_filter} AND metric.type = \"cloudsql.googleapis.com/database/up\""
+      filter = "${local.common_filter} AND metric.type = \"cloudsql.googleapis.com/database/up\""
       aggregations {
         alignment_period     = "60s"
         cross_series_reducer = "REDUCE_NONE"

--- a/simple-tf-pipeline/README.md
+++ b/simple-tf-pipeline/README.md
@@ -52,8 +52,9 @@ No modules.
 | <a name="input_plan_retention_days"></a> [plan\_retention\_days](#input\_plan\_retention\_days) | The number of days terraform plan files are kept in GCS | `number` | `30` | no |
 | <a name="input_project"></a> [project](#input\_project) | n/a | `string` | n/a | yes |
 | <a name="input_storage_location"></a> [storage\_location](#input\_storage\_location) | n/a | `string` | `"EU"` | no |
+| <a name="input_terraform_image"></a> [terraform\_image](#input\_terraform\_image) | n/a | `string` | n/a | yes |
+| <a name="input_trigger_name_suffix"></a> [trigger\_name\_suffix](#input\_trigger\_name\_suffix) | Additional name suffix for multi-environment infrastructures | `string` | `"ops"` | no |
 | <a name="input_working_directory"></a> [working\_directory](#input\_working\_directory) | The path of the root terraform module inside the configured git repository | `string` | `"."` | no |
-| <a name="trigger_name_suffix"></a> [trigger\_name\_suffix](#input\_trigger\_name\_suffix) | Trigger name suffix for multi-project infrastructures | `string` | "ops" | no |
 
 ## Outputs
 


### PR DESCRIPTION
Sorry the formatting updates obfuscate the changes a bit, but we mainly added the `default_region` and `functions_region` and changed the scheduler region to also default to the default region when not specified.
The functions region previously relied on provider default settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aliz-ai/terraform-aliz-modules/20)
<!-- Reviewable:end -->
